### PR TITLE
Updates to match template (workflows)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -17,14 +17,17 @@ permissions:
   contents: write
 
 jobs:
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
       
@@ -34,9 +37,12 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 0
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 0}}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 0}}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -44,7 +50,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -30,7 +30,7 @@ jobs:
           echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_start:
     name: On start
     needs: get_current_step

--- a/.github/workflows/1-first-codespace.yml
+++ b/.github/workflows/1-first-codespace.yml
@@ -19,18 +19,17 @@ permissions:
   contents: write
 
 jobs:
-  # The purpose of this job is to output the current step number 
-  # (retreived from the STEP file). This output variable can
-  # then be referenced in other jobs and used in conditional 
-  # expressions.
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
       
@@ -40,9 +39,12 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 1
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 1 }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 1 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -50,7 +52,9 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Let's get all the branches
 
       # Verify the learner added the file contents
       - name: Check workflow contents, jobs

--- a/.github/workflows/1-first-codespace.yml
+++ b/.github/workflows/1-first-codespace.yml
@@ -32,7 +32,7 @@ jobs:
           echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_add_dependency:
     name: On Add dependency
     needs: get_current_step
@@ -64,7 +64,7 @@ jobs:
         env:
           FILE: "index.html"
           SEARCH: "Hello from the codespace"
-      
+
       # Update README to close <details id=1> and open <details id=2>
       # and set STEP to '2'
       - name: Update to step 2

--- a/.github/workflows/2-custom-image.yml
+++ b/.github/workflows/2-custom-image.yml
@@ -19,18 +19,17 @@ permissions:
   contents: write
 
 jobs:
-  # The purpose of this job is to output the current step number 
-  # (retreived from the STEP file). This output variable can
-  # then be referenced in other jobs and used in conditional 
-  # expressions.
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
       
@@ -40,9 +39,12 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 2
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 2 }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 2 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -50,7 +52,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/2-custom-image.yml
+++ b/.github/workflows/2-custom-image.yml
@@ -32,7 +32,7 @@ jobs:
           echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_DependabotPrCreated:
     name: On Creation of a PR
     needs: get_current_step
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0 # Let's get all the branches
 
       # Verify the devcontainer.json has an image
-      - name: Check package.json
+      - name: Check devcontainer.json
         run: |
           chmod a+x .github/script/check-file.sh
           ./.github/script/check-file.sh
@@ -65,7 +65,6 @@ jobs:
           FILE: ".devcontainer/devcontainer.json"
           SEARCH: "mcr.microsoft.com/vscode/devcontainers/universal:latest"
 
-          
       # Update README to close <details id=2> and open <details id=3>
       # and set STEP to '3'
       - name: Update to step 3

--- a/.github/workflows/3-customize-codespace.yml
+++ b/.github/workflows/3-customize-codespace.yml
@@ -19,18 +19,17 @@ permissions:
   contents: write
 
 jobs:
-  # The purpose of this job is to output the current step number 
-  # (retreived from the STEP file). This output variable can
-  # then be referenced in other jobs and used in conditional 
-  # expressions.
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
       
@@ -40,9 +39,12 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 3
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 3 }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 3 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -50,7 +52,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/3-customize-codespace.yml
+++ b/.github/workflows/3-customize-codespace.yml
@@ -2,7 +2,7 @@ name: Step 3, 3-Customize Codespace
 
 # This step triggers after TBD-step-3-event-desc
 # This step sets STEP to 4
-# This step closes <details id=3> and opens <details id=X>
+# This step closes <details id=3> and opens <details id=4>
 
 # This will run every time
 # Reference https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
@@ -32,7 +32,7 @@ jobs:
           echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_DependabotSecurityUpdates:
     name: On Dependabot Security Updates
     needs: get_current_step
@@ -64,8 +64,7 @@ jobs:
         env:
           FILE: ".devcontainer/devcontainer.json"
           SEARCH: "postCreateCommand"
-    
-          
+
       # Update README to close <details id=3> and open <details id=4>
       # and set STEP to '4'
       - name: Update to step 4

--- a/.github/workflows/4-personalize-codespace.yml
+++ b/.github/workflows/4-personalize-codespace.yml
@@ -1,7 +1,8 @@
 name: Step 4, 4-Personalize your Codespace
+
 # This step triggers after TBD-step-4-event-desc
 # This step sets STEP to X
-# This step closes <details id=3> and opens <details X>
+# This step closes <details id=4> and opens <details X>
 
 # This will run every time we TBD-step-4-event-desc
 # Reference https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
@@ -12,7 +13,7 @@ on:
       - main
     paths:
       - '.github/dependabot.yml'
-      
+
 # Reference https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
   # Need `contents: read` to checkout the repository
@@ -33,7 +34,7 @@ jobs:
           echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_TBD-step-4-event:
     name: On TBD-step-4-event
     needs: get_current_step
@@ -65,8 +66,8 @@ jobs:
         env:
           FILE: "dotfiles/setup.sh"
           SEARCH: "Codespace"
-          
-      # Update README to close <details id=3> and open <details id=X>
+
+      # Update README to close <details id=4> and open <details id=X>
       # and set STEP to 'X'
       - name: Update to step X
         uses: skills/action-update-step@v1

--- a/.github/workflows/4-personalize-codespace.yml
+++ b/.github/workflows/4-personalize-codespace.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/dependabot.yml'
+      - 'setup.sh'
 
 # Reference https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
@@ -64,8 +64,8 @@ jobs:
           chmod a+x .github/script/check-file.sh
           ./.github/script/check-file.sh
         env:
-          FILE: "dotfiles/setup.sh"
-          SEARCH: "Codespace"
+          FILE: "setup.sh"
+          SEARCH: "install sl"
 
       # Update README to close <details id=4> and open <details id=X>
       # and set STEP to 'X'

--- a/.github/workflows/4-personalize-codespace.yml
+++ b/.github/workflows/4-personalize-codespace.yml
@@ -20,18 +20,17 @@ permissions:
   contents: write
 
 jobs:
-  # The purpose of this job is to output the current step number 
-  # (retreived from the STEP file). This output variable can
-  # then be referenced in other jobs and used in conditional 
-  # expressions.
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
       
@@ -41,9 +40,12 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 4
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 4}}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 4}}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -51,7 +53,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 


### PR DESCRIPTION
### Why:

2 warnings
**Check current step number** and **On start**
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
**Check current step number**
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
- Bump actions/checkout@v2 to v3
- Stop using `set-output` commands
- Fix 4-personalize-codespace.yml

### Check off the following:

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
