### PR TITLE
Fix typo in filename

### DIFF
--- a/.github/steps/3-customize-codespace.md
+++ b/.github/steps/3-customize-codespace.md
@@ -10,7 +10,7 @@ _Nice work! :tada: You created a codespace with a custom image!_
 
 You can customize your codespace by adding VS code extensions, adding features, setting host requirements, and much more.
 
-Let's customize some settings in the `.devcontainer.json` file!
+Let's customize some settings in the `devcontainer.json` file!
 
 ### :keyboard: Activity: Add customizations to the `devcontainer` file
 


### PR DESCRIPTION
### Summary
Remove the extra `.` before `devcontainer.json` in the tutorial. Only the folder is hidden, not the file itself. 


### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
