### PR TITLE
Replacing 'create' trigger for 'push' in Step 0

### DIFF
--- a/.github/workflows/0-welcome.yml
+++ b/.github/workflows/0-welcome.yml
@@ -6,7 +6,7 @@ name: Step 0, Welcome
 # This will run every time we create push a commit to `main`.
 # Reference: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
-  create:
+  push:
   workflow_dispatch:
 
 # Reference: https://docs.github.com/en/actions/security-guides/automatic-token-authentication

--- a/.github/workflows/0-welcome.yml
+++ b/.github/workflows/0-welcome.yml
@@ -7,6 +7,8 @@ name: Step 0, Welcome
 # Reference: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   push:
+    branches: 
+      - main
   workflow_dispatch:
 
 # Reference: https://docs.github.com/en/actions/security-guides/automatic-token-authentication


### PR DESCRIPTION
The 'create' trigger does not get picked up once you create a repository from a template. Instead, the 'push' trigger should be used here for this purpose.

### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
When following the steps in the template repository README and creating a new repository from the template, the GitHub Actions Workflow for 'Step 0: Welcome' does not get triggered. This is because the trigger 'create' being used does not trigger the workflow on this type of event. The only exception to this is if the user creates the repository from the template with the checkbox 'Include all branches' selected. This counts as a branch creation and thus triggers the workflow, however this is not the default option and should not be expected of users.

### Changes
<!-- Describe the changes this pull request introduces. -->
Using the `push` trigger. As per [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push), the `push`trigger _runs your workflow when you push a commit or tag, or when you create a repository from a template._

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:
#87 
### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
