### PR TITLE
Check the number of active codespaces before creating a new codespace in Step 3

### DIFF
--- a/.github/steps/3-customize-codespace.md
+++ b/.github/steps/3-customize-codespace.md
@@ -38,6 +38,10 @@ Let's customize some settings in the `devcontainer.json` file!
 1. Create a new codespace by navigating to the landing page of your repository.
 1. Click the **Code** button located in the middle of the page.
 1. Click the **Codespaces** tab on the box that pops up.
+1. Ensure the number of active codespaces does not reach the maximum (typically 2). For more information, see [understanding the codespace lifecycle](https://docs.github.com/en/codespaces/getting-started/understanding-the-codespace-lifecycle).
+
+   > **Tip**: To stop an active codespace, click the **•••** next to **<span>&#x25cf;</span>Active** and select **Stop codespace** from the menu.
+   
 1. Click the **Create codespace on main** button.
 
    > Wait about **2 minutes** for the codespace to spin itself up.


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
Following the steps in the course to continuously create new codespace, until step 3, we may reach the maximum number of active codespaces (typically two) and have to stop one of those before creating a new one.
<img width="400" alt="Snipaste_2024-05-14_14-35-00" src="https://github.com/skills/code-with-codespaces/assets/33929105/ffa46498-74e1-4707-a925-682ac54181f8">


### Changes
<!-- Describe the changes this pull request introduces. -->
Revise the instructions to include checking the number of active codespaces and how to stop an active codespace in [3-customize-codespace.md](https://github.com/skills/code-with-codespaces/blob/9ac889a6fe59d63441af0569d480023a2f074819/.github/steps/3-customize-codespace.md) file.

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: N/A

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).