### PR TITLE
Step 4: Name dotfiles install script 'install.sh'

### DIFF
--- a/.github/steps/4-personalize-codespace.md
+++ b/.github/steps/4-personalize-codespace.md
@@ -37,7 +37,7 @@ Let's see how this works!
 
    ![codespace1](https://user-images.githubusercontent.com/26442605/207355196-71aab43f-35a9-495b-bcfe-bf3773c2f1b3.png)
 
-1. From inside the codespace in the VS Code explorer window, create a new file `setup.sh`.
+1. From inside the codespace in the VS Code explorer window, create a new file `install.sh`.
 1. Add the following code inside of the file:
 
    ```bash
@@ -52,8 +52,8 @@ Let's see how this works!
 1. Commit the file changes. From the VS Code terminal enter:
 
    ```shell
-   git add setup.sh --chmod=+x
-   git commit -m "Adding setup.sh from the codespace!"
+   git add install.sh --chmod=+x
+   git commit -m "Adding install.sh from the codespace!"
    ```
 
 1. Push the changes back to your repository. From the VS Code terminal, enter:
@@ -62,14 +62,14 @@ Let's see how this works!
    git push
    ```
 
-1. Switch back to the homepage of your repository and view the `setup.sh` to verify the new code was pushed to your repository.
+1. Switch back to the homepage of your repository and view the `install.sh` to verify the new code was pushed to your repository.
 1. Close the codespace web browser tab.
 1. Click the **Create codespace on main** button.
 
    > Wait about **2 minutes** for the codespace to spin itself up.
 
 1. Verify your codespace is running, as you did previously.
-1. Verify the `setup.sh` file is present in your VS Code editor.
+1. Verify the `install.sh` file is present in your VS Code editor.
 1. From the VS Code terminal, type or paste:
 
    ```shell

--- a/.github/workflows/4-personalize-codespace.yml
+++ b/.github/workflows/4-personalize-codespace.yml
@@ -1,9 +1,9 @@
 name: Step 4, Personalize your Codespace
 
-# This step triggers after push to main#setup.sh.
+# This step triggers after push to main#install.sh.
 # This workflow updates from step 4 to step X.
 
-# This will run every time we push to main#setup.sh.
+# This will run every time we push to main#install.sh.
 # Reference: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ on:
     branches:
       - main
     paths:
-      - "setup.sh"
+      - "install.sh"
 
 # Reference: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
@@ -56,11 +56,11 @@ jobs:
         with:
           fetch-depth: 0 # Let's get all the branches.
 
-      # Verify the setup.sh added the file contents.
+      # Verify the install.sh added the file contents.
       - name: Check workflow contents, jobs
         uses: skills/action-check-file@v1
         with:
-          file: "setup.sh"
+          file: "install.sh"
           search: "install sl"
 
       # In README.md, switch step 4 for step X.


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Using 'setup.sh' does not seem to work to initiate dotfiles installation (even though [it is documented to][dotfiles]).

[dotfiles]: https://docs.github.com/en/codespaces/setting-your-user-preferences/personalizing-github-codespaces-for-your-account#dotfiles


### Changes
<!-- Describe the changes this pull request introduces. -->

Replace 'setup.sh' with 'install.sh', as `install.sh` does seem to work as expected.

Closes: #98

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- ~[ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).~
I think there were no style-implicated content changes.
