### PR TITLE
Fixing 'command not found' error: Step 4

### DIFF
--- a/.github/steps/4-personalize-codespace.md
+++ b/.github/steps/4-personalize-codespace.md
@@ -45,7 +45,7 @@ Let's see how this works!
 
    sudo apt-get update
    sudo apt-get install sl
-   export PATH=$PATH:/usr/games
+   echo 'export PATH='"$PATH"':/usr/games' >> ~/.bashrc
    ```
 
 1. Save the file.

--- a/.github/steps/4-personalize-codespace.md
+++ b/.github/steps/4-personalize-codespace.md
@@ -45,7 +45,7 @@ Let's see how this works!
 
    sudo apt-get update
    sudo apt-get install sl
-   echo 'export PATH='"$PATH"':/usr/games' >> ~/.bashrc
+   echo "export PATH=\$PATH:/usr/games" >> ~/.bashrc
    ```
 
 1. Save the file.


### PR DESCRIPTION
### Summary
I want fix these bug: `bash: sl: command not found` partialy reported in this issue: #98.

### Changes
I didn't have problem with the installation of _sl_ with _apt-get_, but I notice that the environment variable _/usr/games_ are not included when I try to run `echo $PATH`.   
In my commit, I changed the **setup.sh** code. Now, _/usr/games_ is added to the original _PATH_ variable and it's saved in the _~/.bashrc_ file. This allows you to have the new variable in all open terminals. Therefore, when you try to run the `sl` command, the script starts without errors, allowing you to complete Step 4. 🎉

[Link to Issue 98](https://github.com/skills/code-with-codespaces/issues/98)

### Closes
Hoping that you like this contribution, I wanted to thank you for this exercise, which introduced me to the world of codespaces.
If you have any doubts, please do not hesitate to contact me.
Have a nice day,
Alessandro

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
