### PR TITLE
chore: replace deprecated url for dev container image

### DIFF
--- a/.github/steps/2-custom-image.md
+++ b/.github/steps/2-custom-image.md
@@ -32,7 +32,7 @@ Let's create this file and set a few of the most common settings. For other opti
    ```json
    {
      "name": "Basic Dev Environment",
-     "image": "mcr.microsoft.com/vscode/devcontainers/base:debian"
+     "image": "mcr.microsoft.com/devcontainers/base:debian"
    }
    ```
 


### PR DESCRIPTION
Minor update to the development container configuration to update from a deprecated URL.