### PR TITLE
fix: typo in 2-custom-image.md

### DIFF
--- a/.github/steps/2-custom-image.md
+++ b/.github/steps/2-custom-image.md
@@ -1,6 +1,6 @@
 ## Step 2: Use a custom image in your codespace
 
-The didn't specify any configuration for the codespace we just created, so GitHub used a default Docker image. While this is very useful, it won't be consistent and it doesn't version lock our runtime environment. Specifying the configuration is important to keep the development environment repeatable.
+The repository didn't specify any configuration for the codespace we just created, so GitHub used a default Docker image. While this is very useful, it won't be consistent and it doesn't version lock our runtime environment. Specifying the configuration is important to keep the development environment repeatable.
 
 Let's do that now by providing a specific docker container image.
 


### PR DESCRIPTION
This pull request makes a minor correction to the documentation in `.github/steps/2-custom-image.md`, clarifying the subject of a sentence for better readability.

* Fixed a typo by changing "The didn't specify any configuration..." to "The repository didn't specify any configuration..." in `.github/steps/2-custom-image.md`